### PR TITLE
Refactor: add pm-layout wrappers

### DIFF
--- a/css/partyminder.css
+++ b/css/partyminder.css
@@ -1,27 +1,32 @@
 /* Core PartyMinder styles */
-.page {
+.pm-layout-main {
   padding: 1rem;
 }
 
-.header {
+.pm-header {
   margin-bottom: 1rem;
 }
 
-.section {
+.pm-section {
   margin-bottom: 2rem;
 }
 
-.content-columns {
+.pm-layout-two-column {
   display: flex;
   flex-wrap: wrap;
   gap: 2rem;
+  padding: 1rem;
 }
 
-.column {
+.pm-layout-column {
   flex: 1 1 0;
 }
 
-.form-page .form {
+.pm-layout-form {
+  padding: 1rem;
+}
+
+.pm-layout-form-inner {
   max-width: 600px;
   margin: 0 auto;
 }

--- a/templates/conversations.php
+++ b/templates/conversations.php
@@ -31,8 +31,8 @@ $topics = $conversation_manager->get_topics();
 
 ob_start();
 ?>
-<div class="section">
-    <div class="header">
+<div class="pm-section">
+    <div class="pm-header">
         <h2><?php _e('Discussion Topics', 'partyminder'); ?></h2>
     </div>
     <?php if (!empty($topics)): ?>
@@ -48,7 +48,7 @@ ob_start();
         <p class="text-muted"><?php _e('No conversation topics found.', 'partyminder'); ?></p>
     <?php endif; ?>
     <?php if (is_user_logged_in()): ?>
-        <div class="section">
+        <div class="pm-section">
             <a href="#" class="btn start-conversation-btn"><?php _e('Start Conversation', 'partyminder'); ?></a>
         </div>
     <?php endif; ?>

--- a/templates/layouts/form-page.php
+++ b/templates/layouts/form-page.php
@@ -6,8 +6,8 @@ if (!defined('ABSPATH')) {
     exit;
 }
 ?>
-<div class="page form-page">
-    <div class="form">
+<div class="pm-layout-form">
+    <div class="pm-layout-form-inner">
         <?php echo $form_content ?? ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
     </div>
 </div>

--- a/templates/layouts/main-page.php
+++ b/templates/layouts/main-page.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 ?>
-<div class="page">
+<div class="pm-layout-main">
     <?php
     if (isset($content_template)) {
         include PARTYMINDER_PLUGIN_DIR . 'templates/' . $content_template;

--- a/templates/layouts/two-column-page.php
+++ b/templates/layouts/two-column-page.php
@@ -6,11 +6,11 @@ if (!defined('ABSPATH')) {
     exit;
 }
 ?>
-<div class="page content-columns">
-    <div class="column">
+<div class="pm-layout-two-column">
+    <div class="pm-layout-column">
         <?php echo $main_content ?? ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
     </div>
-    <div class="column">
+    <div class="pm-layout-column">
         <?php
         if (isset($sidebar_template)) {
             include PARTYMINDER_PLUGIN_DIR . 'templates/' . $sidebar_template;

--- a/templates/my-events-content.php
+++ b/templates/my-events-content.php
@@ -51,8 +51,8 @@ if ($user_email) {
 }
 ?>
 
-<div class="section">
-    <div class="header">
+<div class="pm-section">
+    <div class="pm-header">
         <h2><?php _e('My Events', 'partyminder'); ?></h2>
     </div>
 
@@ -90,7 +90,7 @@ if ($user_email) {
     <?php endif; ?>
 
     <?php if (is_user_logged_in()): ?>
-        <div class="section">
+        <div class="pm-section">
             <a href="<?php echo esc_url(PartyMinder::get_create_event_url()); ?>" class="btn"><?php _e('Create Event', 'partyminder'); ?></a>
             <a href="<?php echo esc_url(add_query_arg('show_past', $show_past ? '0' : '1')); ?>" class="btn btn-secondary">
                 <?php echo $show_past ? __('Hide Past Events', 'partyminder') : __('Show Past Events', 'partyminder'); ?>


### PR DESCRIPTION
## Summary
- introduce `pm-layout-*` wrapper classes for main, two-column, and form layouts
- update conversations and my-events templates to use `pm-header` and `pm-section`
- add corresponding layout and header styles

## Testing
- `php -l templates/layouts/main-page.php`
- `php -l templates/layouts/two-column-page.php`
- `php -l templates/layouts/form-page.php`
- `php -l templates/my-events-content.php`
- `php -l templates/conversations.php`
- `grep -o '^\.[a-zA-Z0-9_-]\+' css/partyminder.css | grep -v '^\.pm-' | sort | uniq`


------
https://chatgpt.com/codex/tasks/task_e_6891652ff0348325a94c5267bdaca078