### PR TITLE
Refactor CSS with pm namespace

### DIFF
--- a/assets/css/partyminder.css
+++ b/assets/css/partyminder.css
@@ -63,22 +63,22 @@
     }
     
     /* Target PartyMinder content specifically */
-    body .partyminder-content,
-    main .partyminder-content,
-    article .partyminder-content,
-    section .partyminder-content,
-    div .partyminder-content,
-    .wp-block-group .partyminder-content,
-    .entry-content .partyminder-content,
-    .site-content .partyminder-content,
-    .container .partyminder-content {
+    body .pm-content,
+    main .pm-content,
+    article .pm-content,
+    section .pm-content,
+    div .pm-content,
+    .wp-block-group .pm-content,
+    .entry-content .pm-content,
+    .site-content .pm-content,
+    .container .pm-content {
         padding: 0 !important;
         margin: 0 !important;
     }
     
     /* Override any WordPress theme mobile styles that interfere */
-    .partyminder-content,
-    .partyminder-content * {
+    .pm-content,
+    .pm-content * {
         box-sizing: border-box;
     }
     
@@ -143,7 +143,7 @@
    BASE STYLES
    ============================================================================= */
 
-.partyminder-content {
+.pm-content {
     font-family: var(--pm-font-family);
     line-height: 1.6;
     color: var(--pm-text);
@@ -246,42 +246,33 @@
 
 
 /* Conversations-specific styles */
-.community-stats {
+.pm-community-stats {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 15px;
 }
 
 
-.stat-box {
+.pm-stat-box {
     text-align: center;
     padding: 15px;
     background: var(--pm-surface);
     border-radius: var(--pm-radius);
 }
 
-.stat-number {
+.pm-stat-number {
     font-size: 1.5em;
     font-weight: bold;
     color: var(--pm-primary);
     display: block;
 }
 
-.stat-label {
+.pm-stat-label {
     font-size: 0.85em;
     color: var(--pm-text-muted);
     margin-top: 5px;
 }
 
-.pinned-badge {
-    background: var(--pm-warning);
-    color: var(--pm-white);
-    padding: 2px 8px;
-    border-radius: 12px;
-    font-size: 0.7em;
-    font-weight: bold;
-    text-transform: uppercase;
-}
 
 .pm-flex {
     display: flex;
@@ -936,26 +927,26 @@
 }
 
 /* Modal Tab System */
-.management-tab-btn {
+.pm-management-tab-btn {
     transition: all 0.2s ease;
 }
 
-.management-tab-btn:hover {
+.pm-management-tab-btn:hover {
     background: var(--pm-background) !important;
     color: var(--pm-primary) !important;
 }
 
-.management-tab-btn.active {
+.pm-management-tab-btn.active {
     background: var(--pm-background) !important;
     color: var(--pm-primary) !important;
     border-bottom: 3px solid var(--pm-primary) !important;
 }
 
-.management-tab-pane {
+.pm-management-tab-pane {
     display: none;
 }
 
-.management-tab-pane.active {
+.pm-management-tab-pane.active {
     display: block;
 }
 
@@ -996,8 +987,8 @@
 /* Force filter buttons to stay horizontal on all screen sizes */
 #event-filters,
 #conversation-filters,
-.filter-buttons,
-.events-filter {
+.pm-filter-buttons,
+.pm-events-filter {
     display: flex;
     align-items: center;
     gap: 8px;
@@ -1269,22 +1260,22 @@
    ============================================================================= */
 
 /* Ensure our styles work well with common WordPress themes */
-.partyminder-content * {
+.pm-content * {
     box-sizing: border-box;
 }
 
-.partyminder-content .pm-button {
+.pm-content .pm-button {
     box-sizing: border-box;
 }
 
-.partyminder-content .pm-input,
-.partyminder-content .pm-textarea,
-.partyminder-content .pm-select {
+.pm-content .pm-input,
+.pm-content .pm-textarea,
+.pm-content .pm-select {
     box-sizing: border-box;
 }
 
 /* WordPress admin compatibility */
-.partyminder-content .pm-admin-badge {
+.pm-content .pm-admin-badge {
     display: inline-flex;
     align-items: center;
     padding: 2px 8px;
@@ -1295,7 +1286,7 @@
     font-weight: 500;
 }
 
-.partyminder-content .pm-nav-tab {
+.pm-content .pm-nav-tab {
     display: inline-block;
     padding: 8px 16px;
     margin-right: 4px;
@@ -1307,62 +1298,48 @@
     color: var(--pm-text);
 }
 
-.partyminder-content .pm-nav-tab.active,
-.partyminder-content .pm-nav-tab:hover {
+.pm-content .pm-nav-tab.active,
+.pm-content .pm-nav-tab:hover {
     background: var(--pm-background);
     color: var(--pm-primary);
 }
 
-/* WordPress Theme Compatibility - Override theme spacing */
-.wp-site-blocks .partyminder-content {
-    font-family: var(--pm-font-family);
-    padding: 0 !important;
-    margin: 0 !important;
-}
 
-/* Gutenberg block editor compatibility */
-.wp-block .partyminder-content {
-    font-family: var(--pm-font-family);
-    padding: 0 !important;
-    margin: 0 !important;
-}
-
-/* Twenty Twenty-Five theme compatibility */
-.wp-block-group .partyminder-content,
-.entry-content .partyminder-content {
+/* WordPress and Theme compatibility */
+.pm-content, .wp-site-blocks .pm-content, .wp-block .pm-content, .wp-block-group .pm-content, .entry-content .pm-content {
     font-family: var(--pm-font-family);
     padding: 0 !important;
     margin: 0 !important;
 }
 
 /* Override any WordPress theme container spacing */
-.partyminder-content,
-.partyminder-content .pm-container,
-.partyminder-content .pm-container-wide,
-.partyminder-content .pm-container-narrow {
+.pm-content,
+.pm-content .pm-container,
+.pm-content .pm-container-wide,
+.pm-content .pm-container-narrow {
     box-sizing: border-box;
     padding: 0 !important;
     margin: 0 !important;
 }
 
-.partyminder-content *,
-.partyminder-content *::before,
-.partyminder-content *::after {
+.pm-content *,
+.pm-content *::before,
+.pm-content *::after {
     box-sizing: inherit;
 }
 
 /* Ensure proper font inheritance from theme */
-.partyminder-content {
+.pm-content {
     font-size: inherit;
     line-height: inherit;
 }
 
 /* Override only within our content area, not theme */
-.partyminder-content .pm-text-muted {
+.pm-content .pm-text-muted {
     color: var(--pm-text-muted);
 }
 
-.partyminder-content .pm-heading {
+.pm-content .pm-heading {
     font-family: var(--pm-font-family);
 }
 
@@ -1416,7 +1393,7 @@
    ============================================================================= */
 @media (max-width: 480px) {
     /* ONLY stack general flex containers on very small screens - NOT filter buttons */
-    .pm-flex-center-gap:not(#event-filters):not(#conversation-filters):not(.filter-buttons) {
+    .pm-flex-center-gap:not(#event-filters):not(#conversation-filters):not(.pm-filter-buttons) {
         flex-direction: column;
         align-items: stretch;
     }
@@ -1424,9 +1401,9 @@
     /* Exception: Keep filter buttons and small button groups horizontal */
     #event-filters.pm-flex-center-gap,
     #conversation-filters.pm-flex-center-gap,
-    .pm-flex-center-gap.filter-buttons,
+    .pm-flex-center-gap.pm-filter-buttons,
     .pm-flex-center-gap:has(.filter-btn),
-    .events-filter {
+    .pm-events-filter {
         flex-direction: row !important;
         flex-wrap: nowrap !important;
         gap: var(--mobile-space-sm);
@@ -1462,8 +1439,8 @@
     /* Keep filter buttons horizontal on mobile */
     #event-filters,
     #conversation-filters,
-    .filter-buttons,
-    .events-filter,
+    .pm-filter-buttons,
+    .pm-events-filter,
     .pm-flex-keep-horizontal {
         flex-direction: row !important;
         flex-wrap: wrap;
@@ -1471,7 +1448,7 @@
     }
     
     /* Override any flex-column changes for button groups */
-    .pm-flex-center-gap.filter-buttons,
+    .pm-flex-center-gap.pm-filter-buttons,
     .pm-flex-center-gap:has(.filter-btn) {
         flex-direction: row !important;
     }
@@ -1501,7 +1478,7 @@
     /* Removed old conversations-layout mobile styles - now using unified pm-dashboard-grid */
     
     /* Community Stats */
-    .community-stats {
+    .pm-community-stats {
         grid-template-columns: 1fr;
     }
     
@@ -1528,7 +1505,7 @@
         width: 100%;
     }
     
-    .partyminder-content {
+    .pm-content {
         width: 100%;
         font-size: 16px;
         line-height: 1.6;
@@ -1705,7 +1682,7 @@
    ============================================================================= */
 @media (max-width: 768px) and (-webkit-min-device-pixel-ratio: 2) {
     /* Ensure text is readable on high-DPI screens */
-    .partyminder-content {
+    .pm-content {
         font-size: 17px; /* Slightly larger base font */
     }
     
@@ -2160,7 +2137,7 @@ button.pm-uploading:hover {
 /* Extra Small Mobile (320px and up) - Only special cases */
 @media (max-width: 480px) {
     /* ONLY stack general flex containers on very small screens - NOT filter buttons */
-    .pm-flex-center-gap:not(#event-filters):not(#conversation-filters):not(.filter-buttons) {
+    .pm-flex-center-gap:not(#event-filters):not(#conversation-filters):not(.pm-filter-buttons) {
         flex-direction: column;
         align-items: stretch;
     }
@@ -2168,9 +2145,9 @@ button.pm-uploading:hover {
     /* Exception: Keep filter buttons and small button groups horizontal */
     #event-filters.pm-flex-center-gap,
     #conversation-filters.pm-flex-center-gap,
-    .pm-flex-center-gap.filter-buttons,
+    .pm-flex-center-gap.pm-filter-buttons,
     .pm-flex-center-gap:has(.filter-btn),
-    .events-filter {
+    .pm-events-filter {
         flex-direction: row !important;
         flex-wrap: nowrap !important;
         gap: var(--mobile-space-sm);
@@ -2193,7 +2170,7 @@ button.pm-uploading:hover {
    ============================================================================= */
 
 /* Bluesky Contacts Grid */
-.bluesky-contacts-grid {
+.pm-bluesky-contacts-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: 15px;
@@ -2205,7 +2182,7 @@ button.pm-uploading:hover {
     background: var(--pm-surface);
 }
 
-.bluesky-contact-card {
+.pm-bluesky-contact-card {
     background: var(--pm-background);
     border: 1px solid var(--pm-border);
     border-radius: 8px;
@@ -2214,43 +2191,43 @@ button.pm-uploading:hover {
     transition: all 0.2s ease;
 }
 
-.bluesky-contact-card:hover {
+.pm-bluesky-contact-card:hover {
     border-color: var(--pm-primary);
     box-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
 
-.bluesky-contact-card.selected {
+.pm-bluesky-contact-card.selected {
     border-color: var(--pm-primary);
     background: var(--pm-primary-light);
 }
 
-.bluesky-contact-info {
+.pm-bluesky-contact-info {
     display: flex;
     align-items: center;
     gap: 10px;
 }
 
-.bluesky-contact-avatar {
+.pm-bluesky-contact-avatar {
     width: 40px;
     height: 40px;
     border-radius: 50%;
     object-fit: cover;
 }
 
-.bluesky-contact-details h6 {
+.pm-bluesky-contact-details h6 {
     margin: 0 0 5px 0;
     font-weight: 600;
     color: var(--pm-text);
 }
 
-.bluesky-contact-details p {
+.pm-bluesky-contact-details p {
     margin: 0;
     font-size: 0.9em;
     color: var(--pm-text-muted);
 }
 
 /* Guest Management Styles */
-.guest-item {
+.pm-guest-item {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -2261,24 +2238,24 @@ button.pm-uploading:hover {
     background: var(--pm-surface);
 }
 
-.guest-info h6 {
+.pm-guest-info h6 {
     margin: 0 0 5px 0;
     color: var(--pm-text);
 }
 
-.guest-info p {
+.pm-guest-info p {
     margin: 0;
     font-size: 0.9em;
     color: var(--pm-text-muted);
 }
 
-.guest-status {
+.pm-guest-status {
     display: flex;
     align-items: center;
     gap: 10px;
 }
 
-.status-badge {
+.pm-status-badge {
     padding: 4px 8px;
     border-radius: 4px;
     font-size: 0.8em;
@@ -2286,22 +2263,22 @@ button.pm-uploading:hover {
     text-transform: uppercase;
 }
 
-.status-badge.confirmed { 
+.pm-status-badge-confirmed { 
     background: var(--pm-success-light); 
     color: var(--pm-success); 
 }
 
-.status-badge.pending { 
+.pm-status-badge-pending { 
     background: var(--pm-warning-light); 
     color: var(--pm-warning); 
 }
 
-.status-badge.declined { 
+.pm-status-badge-declined { 
     background: var(--pm-danger-light); 
     color: var(--pm-danger); 
 }
 
-.status-badge.maybe { 
+.pm-status-badge-maybe { 
     background: var(--pm-primary-light); 
     color: var(--pm-primary); 
 }

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -490,7 +490,7 @@
             $('.stat-card').each(function() {
                 const statType = $(this).data('stat-type');
                 if (stats[statType]) {
-                    $(this).find('.stat-number').text(stats[statType]);
+                    $(this).find('.pm-stat-number').text(stats[statType]);
                 }
             });
         },

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -147,16 +147,16 @@ class PartyMinder_Admin {
                     <div class="stat-card">
                         <div class="stat-icon">🎉</div>
                         <div class="stat-content">
-                            <div class="stat-number"><?php echo number_format($total_events); ?></div>
-                            <div class="stat-label"><?php _e('Total Events', 'partyminder'); ?></div>
+                            <div class="pm-stat-number"><?php echo number_format($total_events); ?></div>
+                            <div class="pm-stat-label"><?php _e('Total Events', 'partyminder'); ?></div>
                         </div>
                     </div>
                     
                     <div class="stat-card">
                         <div class="stat-icon">🤖</div>
                         <div class="stat-content">
-                            <div class="stat-number"><?php echo $ai_usage['interactions']; ?></div>
-                            <div class="stat-label"><?php _e('AI Plans Generated', 'partyminder'); ?></div>
+                            <div class="pm-stat-number"><?php echo $ai_usage['interactions']; ?></div>
+                            <div class="pm-stat-label"><?php _e('AI Plans Generated', 'partyminder'); ?></div>
                             <div class="stat-sublabel">$<?php echo number_format($ai_usage['total'], 2); ?> <?php _e('this month', 'partyminder'); ?></div>
                         </div>
                     </div>
@@ -164,8 +164,8 @@ class PartyMinder_Admin {
                     <div class="stat-card">
                         <div class="stat-icon">📅</div>
                         <div class="stat-content">
-                            <div class="stat-number"><?php echo count($upcoming_events); ?></div>
-                            <div class="stat-label"><?php _e('Upcoming Events', 'partyminder'); ?></div>
+                            <div class="pm-stat-number"><?php echo count($upcoming_events); ?></div>
+                            <div class="pm-stat-label"><?php _e('Upcoming Events', 'partyminder'); ?></div>
                         </div>
                     </div>
                 </div>
@@ -1145,7 +1145,7 @@ class PartyMinder_Admin {
                                         <?php endif; ?>
                                     </td>
                                     <td>
-                                        <span class="status-badge" style="padding: 2px 8px; border-radius: 10px; font-size: 0.8em; <?php echo $identity->is_verified ? 'background: #d4edda; color: #155724;' : 'background: #fff3cd; color: #856404;'; ?>">
+                                        <span class="pm-status-badge" style="padding: 2px 8px; border-radius: 10px; font-size: 0.8em; <?php echo $identity->is_verified ? 'background: #d4edda; color: #155724;' : 'background: #fff3cd; color: #856404;'; ?>">
                                             <?php echo $identity->is_verified ? __('Verified', 'partyminder') : __('Pending', 'partyminder'); ?>
                                         </span>
                                     </td>

--- a/partyminder.php
+++ b/partyminder.php
@@ -2400,7 +2400,7 @@ class PartyMinder {
         $event_action = get_query_var('event_action');
         if ($event_action === 'join') {
             ob_start();
-            echo '<div class="partyminder-content partyminder-events-join-page">';
+            echo '<div class="pm-content partyminder-events-join-page">';
             include PARTYMINDER_PLUGIN_DIR . 'templates/event-invitation-accept.php';
             echo '</div>';
             return ob_get_clean();
@@ -2409,7 +2409,7 @@ class PartyMinder {
         ob_start();
         
         // Use theme-friendly wrapper
-        echo '<div class="partyminder-content partyminder-events-page">';
+        echo '<div class="pm-content partyminder-events-page">';
         
         // Include the events template without get_header/get_footer
         $atts = array(
@@ -2440,7 +2440,7 @@ class PartyMinder {
         
         ob_start();
         
-        echo '<div class="partyminder-content partyminder-create-event-page">';
+        echo '<div class="pm-content partyminder-create-event-page">';
         
         // Include create event template
         include PARTYMINDER_PLUGIN_DIR . 'templates/create-event-content.php';
@@ -2467,7 +2467,7 @@ class PartyMinder {
         
         ob_start();
         
-        echo '<div class="partyminder-content partyminder-dashboard-page">';
+        echo '<div class="pm-content partyminder-dashboard-page">';
         
         // Include dashboard template
         $atts = array();
@@ -2495,7 +2495,7 @@ class PartyMinder {
         
         ob_start();
         
-        echo '<div class="partyminder-content partyminder-my-events-page">';
+        echo '<div class="pm-content partyminder-my-events-page">';
         
         // Include my events template
         $atts = array('show_past' => false);
@@ -2523,7 +2523,7 @@ class PartyMinder {
         
         ob_start();
         
-        echo '<div class="partyminder-content partyminder-edit-event-page">';
+        echo '<div class="pm-content partyminder-edit-event-page">';
         
         // Include edit event template
         include PARTYMINDER_PLUGIN_DIR . 'templates/edit-event-content.php';
@@ -2550,7 +2550,7 @@ class PartyMinder {
         
         ob_start();
         
-        echo '<div class="partyminder-content partyminder-login-page">';
+        echo '<div class="pm-content partyminder-login-page">';
         
         // Include login template
         $atts = array();
@@ -2578,7 +2578,7 @@ class PartyMinder {
         
         ob_start();
         
-        echo '<div class="partyminder-content partyminder-profile-page">';
+        echo '<div class="pm-content partyminder-profile-page">';
         
         // Include profile template
         include PARTYMINDER_PLUGIN_DIR . 'templates/profile-content.php';
@@ -2605,7 +2605,7 @@ class PartyMinder {
         
         ob_start();
         
-        echo '<div class="partyminder-content partyminder-conversations-page">';
+        echo '<div class="pm-content partyminder-conversations-page">';
         
         // Include conversations template
         include PARTYMINDER_PLUGIN_DIR . 'templates/conversations-content.php';
@@ -2632,7 +2632,7 @@ class PartyMinder {
         
         ob_start();
         
-        echo '<div class="partyminder-content partyminder-topic-conversations-page">';
+        echo '<div class="pm-content partyminder-topic-conversations-page">';
         
         // Include topic conversations template
         include PARTYMINDER_PLUGIN_DIR . 'templates/topic-conversations-content.php';
@@ -2659,7 +2659,7 @@ class PartyMinder {
         
         ob_start();
         
-        echo '<div class="partyminder-content partyminder-single-conversation-page">';
+        echo '<div class="pm-content partyminder-single-conversation-page">';
         
         // Include single conversation template
         include PARTYMINDER_PLUGIN_DIR . 'templates/single-conversation-content.php';
@@ -2800,14 +2800,14 @@ class PartyMinder {
         $community_action = get_query_var('community_action');
         if ($community_action === 'join') {
             ob_start();
-            echo '<div class="partyminder-content partyminder-communities-join-page">';
+            echo '<div class="pm-content partyminder-communities-join-page">';
             include PARTYMINDER_PLUGIN_DIR . 'templates/community-invitation-accept.php';
             echo '</div>';
             return ob_get_clean();
         }
         
         ob_start();
-        echo '<div class="partyminder-content partyminder-communities-page">';
+        echo '<div class="pm-content partyminder-communities-page">';
         include PARTYMINDER_PLUGIN_DIR . 'templates/communities-content.php';
         echo '</div>';
         return ob_get_clean();
@@ -2824,7 +2824,7 @@ class PartyMinder {
         }
         
         ob_start();
-        echo '<div class="partyminder-content partyminder-communities-disabled">';
+        echo '<div class="pm-content partyminder-communities-disabled">';
         echo '<h2>' . __('Communities Feature Not Available', 'partyminder') . '</h2>';
         echo '<p>' . __('The communities feature is currently disabled. Please check back later.', 'partyminder') . '</p>';
         echo '</div>';
@@ -2847,7 +2847,7 @@ class PartyMinder {
         }
         
         ob_start();
-        echo '<div class="partyminder-content partyminder-single-community-page">';
+        echo '<div class="pm-content partyminder-single-community-page">';
         include PARTYMINDER_PLUGIN_DIR . 'templates/single-community-content.php';
         echo '</div>';
         return ob_get_clean();
@@ -2869,7 +2869,7 @@ class PartyMinder {
         }
         
         ob_start();
-        echo '<div class="partyminder-content partyminder-community-members-page">';
+        echo '<div class="pm-content partyminder-community-members-page">';
         include PARTYMINDER_PLUGIN_DIR . 'templates/community-members-content.php';
         echo '</div>';
         return ob_get_clean();
@@ -2891,7 +2891,7 @@ class PartyMinder {
         }
         
         ob_start();
-        echo '<div class="partyminder-content partyminder-community-events-page">';
+        echo '<div class="pm-content partyminder-community-events-page">';
         include PARTYMINDER_PLUGIN_DIR . 'templates/community-events-content.php';
         echo '</div>';
         return ob_get_clean();
@@ -2910,7 +2910,7 @@ class PartyMinder {
         }
         
         ob_start();
-        echo '<div class="partyminder-content partyminder-manage-community-page">';
+        echo '<div class="pm-content partyminder-manage-community-page">';
         include PARTYMINDER_PLUGIN_DIR . 'templates/manage-community-content.php';
         echo '</div>';
         return ob_get_clean();
@@ -2929,7 +2929,7 @@ class PartyMinder {
         }
         
         ob_start();
-        echo '<div class="partyminder-content partyminder-create-community-page">';
+        echo '<div class="pm-content partyminder-create-community-page">';
         include PARTYMINDER_PLUGIN_DIR . 'templates/create-community-content.php';
         echo '</div>';
         return ob_get_clean();

--- a/templates/communities-content.php
+++ b/templates/communities-content.php
@@ -187,7 +187,7 @@ $secondary_color = get_option('partyminder_secondary_color', '#764ba2');
     margin-bottom: 15px;
 }
 
-.community-stats {
+.pm-community-stats {
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -320,7 +320,7 @@ $secondary_color = get_option('partyminder_secondary_color', '#764ba2');
         text-align: center;
     }
     
-    .community-stats {
+    .pm-community-stats {
         flex-direction: column;
         gap: 10px;
         align-items: stretch;

--- a/templates/community-events-content.php
+++ b/templates/community-events-content.php
@@ -189,7 +189,7 @@ $secondary_color = get_option('partyminder_secondary_color', '#764ba2');
     padding: 30px;
 }
 
-.events-filter {
+.pm-events-filter {
     display: flex;
     gap: 15px;
     margin-bottom: 30px;
@@ -272,7 +272,7 @@ $secondary_color = get_option('partyminder_secondary_color', '#764ba2');
     text-transform: uppercase;
 }
 
-.event-status-badge {
+.pm-event-status-badge {
     position: absolute;
     top: 15px;
     right: 15px;
@@ -283,17 +283,17 @@ $secondary_color = get_option('partyminder_secondary_color', '#764ba2');
     text-transform: uppercase;
 }
 
-.event-status-badge.upcoming {
+.pm-event-status-badge.upcoming {
     background: #28a745;
     color: white;
 }
 
-.event-status-badge.today {
+.pm-event-status-badge.today {
     background: #dc3545;
     color: white;
 }
 
-.event-status-badge.past {
+.pm-event-status-badge.past {
     background: #6c757d;
     color: white;
 }
@@ -448,7 +448,7 @@ $secondary_color = get_option('partyminder_secondary_color', '#764ba2');
         justify-content: center;
     }
     
-    .events-filter {
+    .pm-events-filter {
         justify-content: center;
     }
 }
@@ -555,7 +555,7 @@ $secondary_color = get_option('partyminder_secondary_color', '#764ba2');
             
         <?php else: ?>
             <!-- Event Filters -->
-            <div class="events-filter">
+            <div class="pm-events-filter">
                 <span style="font-weight: 500; color: #666;"><?php _e('Filter:', 'partyminder'); ?></span>
                 <button class="filter-button active" data-filter="all">
                     <?php _e('All Events', 'partyminder'); ?>
@@ -595,7 +595,7 @@ $secondary_color = get_option('partyminder_secondary_color', '#764ba2');
                                 <div class="event-date-month"><?php echo $event_date->format('M'); ?></div>
                             </div>
                             
-                            <div class="event-status-badge <?php echo $status_class; ?>">
+                            <div class="pm-event-status-badge <?php echo $status_class; ?>">
                                 <?php echo $status_text; ?>
                             </div>
                         </div>

--- a/templates/community-members-content.php
+++ b/templates/community-members-content.php
@@ -313,14 +313,14 @@ $secondary_color = get_option('partyminder_secondary_color', '#764ba2');
     text-align: center;
 }
 
-.stat-number {
+.pm-stat-number {
     font-size: 2em;
     font-weight: bold;
     color: var(--pm-primary);
     margin: 0;
 }
 
-.stat-label {
+.pm-stat-label {
     color: #666;
     font-size: 0.9em;
     margin: 5px 0 0 0;
@@ -454,25 +454,25 @@ $secondary_color = get_option('partyminder_secondary_color', '#764ba2');
             
             <div class="members-stats">
                 <div class="stat-card">
-                    <div class="stat-number"><?php echo $admin_count; ?></div>
-                    <div class="stat-label"><?php echo $admin_count === 1 ? __('Admin', 'partyminder') : __('Admins', 'partyminder'); ?></div>
+                    <div class="pm-stat-number"><?php echo $admin_count; ?></div>
+                    <div class="pm-stat-label"><?php echo $admin_count === 1 ? __('Admin', 'partyminder') : __('Admins', 'partyminder'); ?></div>
                 </div>
                 
                 <?php if ($moderator_count > 0): ?>
                 <div class="stat-card">
-                    <div class="stat-number"><?php echo $moderator_count; ?></div>
-                    <div class="stat-label"><?php echo $moderator_count === 1 ? __('Moderator', 'partyminder') : __('Moderators', 'partyminder'); ?></div>
+                    <div class="pm-stat-number"><?php echo $moderator_count; ?></div>
+                    <div class="pm-stat-label"><?php echo $moderator_count === 1 ? __('Moderator', 'partyminder') : __('Moderators', 'partyminder'); ?></div>
                 </div>
                 <?php endif; ?>
                 
                 <div class="stat-card">
-                    <div class="stat-number"><?php echo $member_count_regular; ?></div>
-                    <div class="stat-label"><?php echo $member_count_regular === 1 ? __('Member', 'partyminder') : __('Members', 'partyminder'); ?></div>
+                    <div class="pm-stat-number"><?php echo $member_count_regular; ?></div>
+                    <div class="pm-stat-label"><?php echo $member_count_regular === 1 ? __('Member', 'partyminder') : __('Members', 'partyminder'); ?></div>
                 </div>
                 
                 <div class="stat-card">
-                    <div class="stat-number"><?php echo count($members); ?></div>
-                    <div class="stat-label"><?php _e('Total', 'partyminder'); ?></div>
+                    <div class="pm-stat-number"><?php echo count($members); ?></div>
+                    <div class="pm-stat-label"><?php _e('Total', 'partyminder'); ?></div>
                 </div>
             </div>
 

--- a/templates/conversations.php
+++ b/templates/conversations.php
@@ -212,22 +212,22 @@ $secondary_color = get_option('partyminder_secondary_color', '#764ba2');
                     <?php _e('Community Stats', 'partyminder'); ?>
                 </div>
                 <div class="pm-card-body">
-                    <div class="community-stats">
-                        <div class="stat-box">
-                            <span class="stat-number"><?php echo $stats->total_conversations; ?></span>
-                            <div class="stat-label"><?php _e('Conversations', 'partyminder'); ?></div>
+                    <div class="pm-community-stats">
+                        <div class="pm-stat-box">
+                            <span class="pm-stat-number"><?php echo $stats->total_conversations; ?></span>
+                            <div class="pm-stat-label"><?php _e('Conversations', 'partyminder'); ?></div>
                         </div>
-                        <div class="stat-box">
-                            <span class="stat-number"><?php echo $stats->total_replies; ?></span>
-                            <div class="stat-label"><?php _e('Messages', 'partyminder'); ?></div>
+                        <div class="pm-stat-box">
+                            <span class="pm-stat-number"><?php echo $stats->total_replies; ?></span>
+                            <div class="pm-stat-label"><?php _e('Messages', 'partyminder'); ?></div>
                         </div>
-                        <div class="stat-box">
-                            <span class="stat-number"><?php echo $stats->active_conversations; ?></span>
-                            <div class="stat-label"><?php _e('Active This Week', 'partyminder'); ?></div>
+                        <div class="pm-stat-box">
+                            <span class="pm-stat-number"><?php echo $stats->active_conversations; ?></span>
+                            <div class="pm-stat-label"><?php _e('Active This Week', 'partyminder'); ?></div>
                         </div>
-                        <div class="stat-box">
-                            <span class="stat-number"><?php echo $stats->total_follows; ?></span>
-                            <div class="stat-label"><?php _e('Following', 'partyminder'); ?></div>
+                        <div class="pm-stat-box">
+                            <span class="pm-stat-number"><?php echo $stats->total_follows; ?></span>
+                            <div class="pm-stat-label"><?php _e('Following', 'partyminder'); ?></div>
                         </div>
                     </div>
                 </div>

--- a/templates/events-list-content.php
+++ b/templates/events-list-content.php
@@ -68,7 +68,7 @@ $button_style = get_option('partyminder_button_style', 'rounded');
     background: <?php echo esc_attr($primary_color); ?>;
 }
 
-.partyminder-events-content .stat-number {
+.partyminder-events-content .pm-stat-number {
     color: <?php echo esc_attr($primary_color); ?>;
 }
 </style>

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -194,13 +194,13 @@ $button_style = get_option('partyminder_button_style', 'rounded');
     text-align: center;
 }
 
-.stat-number {
+.pm-stat-number {
     font-size: 2em;
     font-weight: bold;
     color: var(--pm-primary);
 }
 
-.stat-label {
+.pm-stat-label {
     color: #666;
     font-size: 0.9em;
 }
@@ -240,8 +240,8 @@ $button_style = get_option('partyminder_button_style', 'rounded');
         
         <div class="events-stats">
             <span class="stat-item">
-                <span class="stat-number"><?php echo count($events); ?></span>
-                <span class="stat-label"><?php _e('Events', 'partyminder'); ?></span>
+                <span class="pm-stat-number"><?php echo count($events); ?></span>
+                <span class="pm-stat-label"><?php _e('Events', 'partyminder'); ?></span>
             </span>
         </div>
     </div>

--- a/templates/manage-community-content.php
+++ b/templates/manage-community-content.php
@@ -140,7 +140,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
     margin-bottom: 0;
 }
 
-.management-tab-btn {
+.pm-management-tab-btn {
     flex: 1;
     background: none;
     border: none;
@@ -156,8 +156,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
     text-align: center;
 }
 
-.management-tab-btn:hover,
-.management-tab-btn.active {
+.pm-management-tab-btn:hover,
+.pm-management-tab-btn.active {
     color: var(--pm-primary);
     border-bottom-color: var(--pm-primary);
     background: var(--pm-surface);
@@ -293,14 +293,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
     text-align: center;
 }
 
-.stat-number {
+.pm-stat-number {
     font-size: 2rem;
     font-weight: bold;
     color: var(--pm-primary);
     margin-bottom: 5px;
 }
 
-.stat-label {
+.pm-stat-label {
     color: var(--pm-text-muted);
     font-size: 14px;
 }
@@ -453,19 +453,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
     <!-- Tab Navigation -->
     <div class="management-tabs">
         <a href="?community_id=<?php echo $community_id; ?>&tab=overview" 
-           class="management-tab-btn <?php echo $current_tab === 'overview' ? 'active' : ''; ?>">
+           class="pm-management-tab-btn <?php echo $current_tab === 'overview' ? 'active' : ''; ?>">
             <?php _e('Overview', 'partyminder'); ?>
         </a>
         <a href="?community_id=<?php echo $community_id; ?>&tab=settings" 
-           class="management-tab-btn <?php echo $current_tab === 'settings' ? 'active' : ''; ?>">
+           class="pm-management-tab-btn <?php echo $current_tab === 'settings' ? 'active' : ''; ?>">
             <?php _e('Settings', 'partyminder'); ?>
         </a>
         <a href="?community_id=<?php echo $community_id; ?>&tab=members" 
-           class="management-tab-btn <?php echo $current_tab === 'members' ? 'active' : ''; ?>">
+           class="pm-management-tab-btn <?php echo $current_tab === 'members' ? 'active' : ''; ?>">
             <?php _e('Members', 'partyminder'); ?>
         </a>
         <a href="?community_id=<?php echo $community_id; ?>&tab=invitations" 
-           class="management-tab-btn <?php echo $current_tab === 'invitations' ? 'active' : ''; ?>">
+           class="pm-management-tab-btn <?php echo $current_tab === 'invitations' ? 'active' : ''; ?>">
             <?php _e('Invitations', 'partyminder'); ?>
         </a>
     </div>
@@ -477,22 +477,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
         <div id="overview-tab" class="tab-pane <?php echo $current_tab === 'overview' ? 'active' : ''; ?>">
             <h3><?php _e('Community Overview', 'partyminder'); ?></h3>
             
-            <div class="stats-grid" id="community-stats">
+            <div class="stats-grid" id="pm-community-stats">
                 <div class="stat-card">
-                    <div class="stat-number" id="total-members">-</div>
-                    <div class="stat-label"><?php _e('Total Members', 'partyminder'); ?></div>
+                    <div class="pm-stat-number" id="total-members">-</div>
+                    <div class="pm-stat-label"><?php _e('Total Members', 'partyminder'); ?></div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-number" id="active-members">-</div>
-                    <div class="stat-label"><?php _e('Active Members', 'partyminder'); ?></div>
+                    <div class="pm-stat-number" id="active-members">-</div>
+                    <div class="pm-stat-label"><?php _e('Active Members', 'partyminder'); ?></div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-number" id="pending-invites">-</div>
-                    <div class="stat-label"><?php _e('Pending Invites', 'partyminder'); ?></div>
+                    <div class="pm-stat-number" id="pending-invites">-</div>
+                    <div class="pm-stat-label"><?php _e('Pending Invites', 'partyminder'); ?></div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-number" id="community-events">-</div>
-                    <div class="stat-label"><?php _e('Community Events', 'partyminder'); ?></div>
+                    <div class="pm-stat-number" id="community-events">-</div>
+                    <div class="pm-stat-label"><?php _e('Community Events', 'partyminder'); ?></div>
                 </div>
             </div>
 

--- a/templates/my-events.php
+++ b/templates/my-events.php
@@ -233,13 +233,13 @@ $button_style = get_option('partyminder_button_style', 'rounded');
     flex: 1;
 }
 
-.stat-number {
+.pm-stat-number {
     font-size: 1.2em;
     font-weight: bold;
     color: var(--pm-primary);
 }
 
-.stat-label {
+.pm-stat-label {
     font-size: 0.8em;
     color: #666;
 }
@@ -405,16 +405,16 @@ $button_style = get_option('partyminder_button_style', 'rounded');
 
                         <div class="event-stats">
                             <div class="stat-item">
-                                <div class="stat-number"><?php echo $event->guest_stats->confirmed; ?></div>
-                                <div class="stat-label"><?php _e('Confirmed', 'partyminder'); ?></div>
+                                <div class="pm-stat-number"><?php echo $event->guest_stats->confirmed; ?></div>
+                                <div class="pm-stat-label"><?php _e('Confirmed', 'partyminder'); ?></div>
                             </div>
                             <div class="stat-item">
-                                <div class="stat-number"><?php echo $event->guest_stats->maybe; ?></div>
-                                <div class="stat-label"><?php _e('Maybe', 'partyminder'); ?></div>
+                                <div class="pm-stat-number"><?php echo $event->guest_stats->maybe; ?></div>
+                                <div class="pm-stat-label"><?php _e('Maybe', 'partyminder'); ?></div>
                             </div>
                             <div class="stat-item">
-                                <div class="stat-number"><?php echo $event->guest_stats->pending; ?></div>
-                                <div class="stat-label"><?php _e('Pending', 'partyminder'); ?></div>
+                                <div class="pm-stat-number"><?php echo $event->guest_stats->pending; ?></div>
+                                <div class="pm-stat-label"><?php _e('Pending', 'partyminder'); ?></div>
                             </div>
                         </div>
 

--- a/templates/rsvp-form.php
+++ b/templates/rsvp-form.php
@@ -300,14 +300,14 @@ $form_layout = get_option('partyminder_form_layout', 'card');
         
         <div class="guest-stats">
             <div class="stat-item">
-                <span class="stat-number"><?php echo $guest_stats->confirmed; ?></span>
-                <span class="stat-label"><?php _e('Confirmed', 'partyminder'); ?></span>
+                <span class="pm-stat-number"><?php echo $guest_stats->confirmed; ?></span>
+                <span class="pm-stat-label"><?php _e('Confirmed', 'partyminder'); ?></span>
             </div>
             
             <?php if ($guest_stats->maybe > 0): ?>
             <div class="stat-item">
-                <span class="stat-number"><?php echo $guest_stats->maybe; ?></span>
-                <span class="stat-label"><?php _e('Maybe', 'partyminder'); ?></span>
+                <span class="pm-stat-number"><?php echo $guest_stats->maybe; ?></span>
+                <span class="pm-stat-label"><?php _e('Maybe', 'partyminder'); ?></span>
             </div>
             <?php endif; ?>
         </div>

--- a/templates/single-community-content.php
+++ b/templates/single-community-content.php
@@ -157,7 +157,7 @@ $secondary_color = get_option('partyminder_secondary_color', '#764ba2');
     gap: 15px;
 }
 
-.community-stats {
+.pm-community-stats {
     display: flex;
     gap: 30px;
     align-items: center;
@@ -171,7 +171,7 @@ $secondary_color = get_option('partyminder_secondary_color', '#764ba2');
     font-size: 1em;
 }
 
-.stat-number {
+.pm-stat-number {
     font-weight: bold;
     color: var(--pm-primary);
 }
@@ -334,7 +334,7 @@ $secondary_color = get_option('partyminder_secondary_color', '#764ba2');
         gap: 20px;
     }
     
-    .community-stats {
+    .pm-community-stats {
         justify-content: center;
         flex-wrap: wrap;
     }
@@ -392,18 +392,18 @@ $secondary_color = get_option('partyminder_secondary_color', '#764ba2');
         </div>
         
         <div class="community-actions">
-            <div class="community-stats">
+            <div class="pm-community-stats">
                 <div class="stat-item">
                     <span>👥</span>
-                    <span><span class="stat-number"><?php echo $stats->member_count; ?></span> <?php echo $stats->member_count === 1 ? __('member', 'partyminder') : __('members', 'partyminder'); ?></span>
+                    <span><span class="pm-stat-number"><?php echo $stats->member_count; ?></span> <?php echo $stats->member_count === 1 ? __('member', 'partyminder') : __('members', 'partyminder'); ?></span>
                 </div>
                 <div class="stat-item">
                     <span>🗓️</span>
-                    <span><span class="stat-number"><?php echo $stats->event_count; ?></span> <?php echo $stats->event_count === 1 ? __('event', 'partyminder') : __('events', 'partyminder'); ?></span>
+                    <span><span class="pm-stat-number"><?php echo $stats->event_count; ?></span> <?php echo $stats->event_count === 1 ? __('event', 'partyminder') : __('events', 'partyminder'); ?></span>
                 </div>
                 <div class="stat-item">
                     <span>📈</span>
-                    <span><span class="stat-number"><?php echo $stats->recent_activity; ?></span> <?php _e('active this month', 'partyminder'); ?></span>
+                    <span><span class="pm-stat-number"><?php echo $stats->recent_activity; ?></span> <?php _e('active this month', 'partyminder'); ?></span>
                 </div>
             </div>
             

--- a/templates/single-event-content.php
+++ b/templates/single-event-content.php
@@ -244,7 +244,7 @@ $event_conversations = $conversation_manager->get_event_conversations($event->id
                     <input type="text" class="pm-input" id="contacts-search" 
                            placeholder="<?php _e('Search your contacts...', 'partyminder'); ?>">
                 </div>
-                <div id="bluesky-contacts-list" class="bluesky-contacts-grid">
+                <div id="bluesky-contacts-list" class="pm-bluesky-contacts-grid">
                     <!-- Contacts will be loaded here -->
                 </div>
             </div>
@@ -634,13 +634,13 @@ document.addEventListener('DOMContentLoaded', function() {
             const typeLabel = entry.type === 'invitation' ? '<?php _e('(Invited)', 'partyminder'); ?>' : '';
             
             return `
-                <div class="guest-item">
-                    <div class="guest-info">
+                <div class="pm-guest-item">
+                    <div class="pm-guest-info">
                         <h6>${displayName} ${typeLabel}</h6>
                         <p>${email}</p>
                     </div>
-                    <div class="guest-status">
-                        <span class="status-badge ${status}">${status}</span>
+                    <div class="pm-guest-status">
+                        <span class="pm-status-badge pm-status-badge-${status}">${status}</span>
                     </div>
                 </div>
             `;
@@ -700,7 +700,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 <div class="pm-modal pm-modal-sm">
                     <div class="pm-modal-header">
                         <h3>🦋 <?php _e('Connect to Bluesky', 'partyminder'); ?></h3>
-                        <button type="button" class="bluesky-connect-close pm-button pm-button-secondary" style="padding: 5px; border-radius: 50%; width: 35px; height: 35px;">×</button>
+                        <button type="button" class="pm-bluesky-connect-close pm-button pm-button-secondary" style="padding: 5px; border-radius: 50%; width: 35px; height: 35px;">×</button>
                     </div>
                     <div class="pm-modal-body">
                         <form id="bluesky-connect-form">
@@ -721,7 +721,7 @@ document.addEventListener('DOMContentLoaded', function() {
                                 <button type="submit" class="pm-button pm-button-primary">
                                     <?php _e('Connect Account', 'partyminder'); ?>
                                 </button>
-                                <button type="button" class="bluesky-connect-close pm-button pm-button-secondary">
+                                <button type="button" class="pm-bluesky-connect-close pm-button pm-button-secondary">
                                     <?php _e('Cancel', 'partyminder'); ?>
                                 </button>
                             </div>
@@ -737,7 +737,7 @@ document.addEventListener('DOMContentLoaded', function() {
         connectModal.classList.add('active');
         
         // Close handlers
-        connectModal.querySelectorAll('.bluesky-connect-close').forEach(btn => {
+        connectModal.querySelectorAll('.pm-bluesky-connect-close').forEach(btn => {
             btn.addEventListener('click', () => {
                 connectModal.remove();
             });
@@ -827,11 +827,11 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         
         const html = contacts.map(contact => `
-            <div class="bluesky-contact-card" data-contact='${JSON.stringify(contact)}'>
-                <div class="bluesky-contact-info">
-                    <img src="${contact.avatar || ''}" alt="${contact.displayName || contact.handle}" class="bluesky-contact-avatar" 
+            <div class="pm-bluesky-contact-card" data-contact='${JSON.stringify(contact)}'>
+                <div class="pm-bluesky-contact-info">
+                    <img src="${contact.avatar || ''}" alt="${contact.displayName || contact.handle}" class="pm-bluesky-contact-avatar" 
                          onerror="this.src='data:image/svg+xml,<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 40 40\\"><circle cx=\\"20\\" cy=\\"20\\" r=\\"20\\" fill=\\"#ddd\\"/><text x=\\"20\\" y=\\"26\\" text-anchor=\\"middle\\" fill=\\"white\\" font-size=\\"16\\">${(contact.displayName || contact.handle).charAt(0).toUpperCase()}</text></svg>'">
-                    <div class="bluesky-contact-details">
+                    <div class="pm-bluesky-contact-details">
                         <h6>${contact.displayName || contact.handle}</h6>
                         <p>@${contact.handle}</p>
                     </div>
@@ -842,7 +842,7 @@ document.addEventListener('DOMContentLoaded', function() {
         container.innerHTML = html;
         
         // Add click handlers
-        container.querySelectorAll('.bluesky-contact-card').forEach(card => {
+        container.querySelectorAll('.pm-bluesky-contact-card').forEach(card => {
             card.addEventListener('click', function() {
                 const contactData = JSON.parse(this.getAttribute('data-contact'));
                 selectBlueskyContact(contactData);
@@ -857,7 +857,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         
         // Visual feedback
-        document.querySelectorAll('.bluesky-contact-card').forEach(card => {
+        document.querySelectorAll('.pm-bluesky-contact-card').forEach(card => {
             card.classList.remove('selected');
         });
         event.currentTarget.classList.add('selected');


### PR DESCRIPTION
## Summary
- namespace previously generic CSS classes and reorganize theme override block
- update PHP templates and admin script to align with new pm- prefixed styles

## Testing
- `grep -o '^\.[a-zA-Z0-9_-]\+' assets/css/partyminder.css | grep -v '^\.pm-' | sort | uniq`
- `for file in includes/class-admin.php partyminder.php templates/communities-content.php templates/community-events-content.php templates/community-members-content.php templates/conversations.php templates/events-list-content.php templates/events-list.php templates/manage-community-content.php templates/my-events.php templates/rsvp-form.php templates/single-community-content.php templates/single-event-content.php; do php -l $file; done`


------
https://chatgpt.com/codex/tasks/task_e_6891758ca1a88325a920789c54d82daa